### PR TITLE
feat(roll-call): support weighted probability

### DIFF
--- a/__tests__/roll-call.spec.ts
+++ b/__tests__/roll-call.spec.ts
@@ -95,3 +95,117 @@ describe.concurrent.todo('useRollCall', () => {
     expect(inst.value.currentValue).toBeUndefined();
   });
 });
+
+describe('useRollCall (weighted)', () => {
+  // 直接调用 next() 避免定时器带来的 flakiness；只验证队列展开与循环逻辑
+  it('按权重展开待选队列并循环（A1 B2 C3 → A B B C C C A ...）', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration: 0, weight: 1 },
+        { value: 'B', duration: 0, weight: 2 },
+        { value: 'C', duration: 0, weight: 3 },
+      ],
+      duration: 100,
+    });
+    const expected = ['A', 'B', 'B', 'C', 'C', 'C', 'A'];
+    for (const v of expected) {
+      inst.value.next();
+      expect(inst.value.currentValue).toBe(v);
+    }
+    expect(inst.value.currentIndex).toBe(0); // 7th next() wraps to index 0
+  });
+
+  it('未指定 weight 时默认为 1（与纯字符串等价）', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration: 0 },
+        { value: 'B', duration: 0, weight: 2 },
+      ],
+      duration: 100,
+    });
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A'); // wrap
+  });
+
+  it('纯字符串与带权重的对象混合', () => {
+    const inst = useRollCall({
+      options: ['A', { value: 'B', duration: 0, weight: 2 }],
+      duration: 100,
+    });
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+  });
+
+  it('weight < 1 视为 1', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration: 0, weight: 0 },
+        { value: 'B', duration: 0, weight: -3 },
+      ],
+      duration: 100,
+    });
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+  });
+
+  it('weight 为非有限值（NaN / Infinity）时视为 1，不抛错也不死循环', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration: 0, weight: Number.NaN },
+        { value: 'B', duration: 0, weight: Number.POSITIVE_INFINITY },
+        { value: 'C', duration: 0, weight: Number.NEGATIVE_INFINITY },
+      ],
+      duration: 100,
+    });
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('C');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+  });
+
+  it('weight 为非整数时向下取整（>=2 的小数取整后仍 >1，区别于"视为 1"）', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration: 0, weight: 2.9 }, // → 2
+        { value: 'B', duration: 0, weight: 1.9 }, // → 1
+      ],
+      duration: 100,
+    });
+    // 展开队列为 [A, A, B]，能区分"向下取整"（2.9→2）与"视为 1"（2.9→1）
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentValue).toBe('A'); // wrap
+  });
+
+  it('空 options 时 next() 不抛错且不改变状态', () => {
+    const inst = useRollCall({ options: [], duration: 100 });
+    expect(() => inst.value.next()).not.toThrow();
+    expect(inst.value.currentValue).toBeUndefined();
+    expect(inst.value.currentIndex).toBeUndefined();
+  });
+});

--- a/src/utils/roll-call.ts
+++ b/src/utils/roll-call.ts
@@ -8,6 +8,17 @@ export interface RollCallAdvancedOption {
   value: string
   /** 此选项在随机时停留的时间（单位：ms） */
   duration: number
+  /**
+   * 此选项的权重（默认为 1）。
+   *
+   * 权重为 n 的选项会在待选队列中占据 n 个位置，因此被抽中的概率正比于权重。
+   * 例如 `A1 B2 C3` 展开后的待选队列为 `A B B C C C`。
+   *
+   * - 非整数权重向下取整（如 `2.9` → `2`）。
+   * - 权重小于 1 的值（如 `0`、负数）会被视为 1。
+   * - 非有限值（如 `NaN` / `±Infinity`）会被视为 1，避免展开时死循环或静默丢弃选项。
+   */
+  weight?: number
 }
 
 /** 待点选项 */
@@ -27,7 +38,7 @@ export interface RollCallConfig {
 export interface RollCallController {
   /** 当前随机值 */
   currentValue?: string
-  /** 当前随机值的下标 */
+  /** 当前随机值的下标（在按权重展开后的待选队列中） */
   currentIndex?: number
   /** 前进到下一个选项 */
   next: () => void
@@ -42,6 +53,28 @@ export interface RollCallController {
 }
 
 /**
+ * 把 `RollCallOption` 展开为按权重重复的待选队列。
+ *
+ * - 字符串视为权重 1。
+ * - 对象的权重默认为 1。
+ * - 权重小于 1 的值会被视为 1。
+ * - 非有限值（`NaN` / `±Infinity`）会被视为 1，避免展开时死循环或静默丢弃选项。
+ * - 非整数权重向下取整。
+ */
+function expandOptions(options: RollCallOption[]): RollCallOption[] {
+  const queue: RollCallOption[] = [];
+  for (const option of options) {
+    const declared = typeof option === 'object' ? option.weight : undefined;
+    const weight = declared !== undefined && Number.isFinite(declared)
+      ? Math.max(1, Math.floor(declared))
+      : 1;
+    for (let i = 0; i < weight; i++)
+      queue.push(option);
+  }
+  return queue;
+}
+
+/**
  * 点名。
  *
  * 默认暂停，需要调用返回值的 `.value.start()` 来开始。
@@ -49,15 +82,20 @@ export interface RollCallController {
 export default function useRollCall(config: RollCallConfig): Ref<RollCallController> {
   const { options, duration, defaultIndex, defaultValue } = config;
 
+  // 按权重展开待选队列（无权重时退化为原 options）
+  const queue = expandOptions(options);
+
   const currentIndex = ref<number | undefined>(defaultIndex);
   const currentValue = ref<string | undefined>(defaultValue);
   const currentDuration = ref(duration);
 
   const next = () => {
+    if (queue.length === 0) // 空名单保护：避免在无待点选项时访问 queue[0] 报错
+      return;
     let i = (currentIndex.value ?? -1) + 1; // 若未开始，下一个为第一个，即下标 -1+1
-    if (i >= options.length) // 越界
+    if (i >= queue.length) // 越界
       i = 0;
-    const incoming = options[i]!;
+    const incoming = queue[i]!;
     currentValue.value = rollCallOptionToString(incoming);
     currentIndex.value = i;
 


### PR DESCRIPTION
## What

Resolves #61.

为 `useRollCall` 增加按权重调整抽取概率的能力：在 `RollCallAdvancedOption` 上新增可选字段 `weight`（默认 `1`）。启动后，待选队列会按权重展开，例如 `A1 B2 C3` 展开后为 `A B B C C C`，从而让停在某个选项上的概率正比于其权重。

## Why

`#61` 的需求是让某些选项（如「重点关注名单」）在点名时被抽中的概率更高。当前实现是均匀轮询，无法表达这种偏好。原 issue 给出的精确规格是：

> 如 `A1 B2 C3`，则待选队列为 `A B B C C C`

本 PR 按此规格实现。

## Changes

- `src/utils/roll-call.ts`
  - `RollCallAdvancedOption` 新增可选 `weight?: number`。
  - 新增内部 `expandOptions()`，按权重把 `options` 展开为待选队列。无权重时退化为原 `options`，行为不变。
  - `next()` 改为在展开后的队列上循环；`currentIndex` 现在指向展开队列中的位置（对纯字符串场景与原 `options` 下标一致）。
  - **轻微行为改进**：在 `next()` 开头新增 `if (queue.length === 0) return;` 守卫。原实现在 `options` 为空时调用 `next()` 会抛 `TypeError`（读取 `undefined.value`），现在会安静地不改变状态。这避免了用户清空名单后点名直接崩 UI 的边缘情况，符合 `RollCallController` 接口「不抛错」的预期。
  - **衍生行为说明（空名单下 `start()`）**：上述守卫让 `start()` 在空名单下不再崩。调用 `start()` 时 `isActive` 会变为 `true`、interval 会以 `duration` 周期回调 `next()`（每次都命中空队列守卫、不改变状态），`currentValue` 始终保持 `undefined`。这仍优于原代码（原 `start()` 在空名单下直接抛 `TypeError`）。如果维护者希望空名单下 `start()` 也直接保持暂停，可以在 `start()` 入口加同样的 `if (queue.length === 0) return;`，留作后续 PR。
- `__tests__/roll-call.spec.ts`
  - 新增独立的 `describe('useRollCall (weighted)', ...)` 块，覆盖：按权重展开+循环（`A1 B2 C3 → A B B C C C A`）、默认权重 1、字符串与对象混合、`weight < 1` 视为 1、`NaN`/`Infinity` 等非有限值视为 1、非整数向下取整（用 `weight: 2.9` 验证取整后仍 >1 以区别于"视为 1"）、空 options 不抛错。
  - 既有的 `describe.concurrent.todo('useRollCall', ...)` 块保持不变（本次不动它）。
  - 测试均为同步（直接调用 `.next()`），不依赖定时器，避免 flakiness。

## Backward compatibility

- 纯字符串与 `{ value, duration }` 形式的选项行为完全不变（权重默认 1）。
- `defaultIndex` 仍指向展开后队列中的位置；对无权重场景与原 `options` 下标一致。
- 唯一的行为变化：空 `options` 下调用 `next()` 不再抛 `TypeError`，而是安静返回；连带 `start()` 在空名单下也不再崩（`isActive` 变 `true` 但 `currentValue` 保持 `undefined`，详见上文 Changes 中「衍生行为说明」）。这是防御性改进，不影响任何现有调用路径。

## Out of scope (follow-up PRs welcome)

- 名单编辑器 UI 暴露 `weight` 字段（需要更新 zod schema 与 `dynamic-input.tsx`）。
- 启用既有 `.todo` 测试块（依赖真实定时器，维护者已用 `if: 0` 在 CI 中关闭，留待后续单独处理）。

## Verification

- `bun run lint` ✅ exit 0
- `bun run test`（新增的 `useRollCall (weighted)` 块全部通过；既有 `.todo` 块仍 skipped）✅ roll-call 单文件 `bun run test -- __tests__/roll-call.spec.ts` exit 0（新增 7 项全通过，既有 `.todo` 7 项 skipped）。注：完整 `bun run test` 退出码 1，失败来自 `__tests__/namelist.spec.ts` 预存在的 zod v4 加载错误（`z.object` undefined，在 pristine HEAD `01fa2fe` 即复现，与本 PR 无关）。
- `bun run --config=bunfig.vue-tsc.toml type-check:app` ✅ exit 0
- `bun run --config=bunfig.vue-tsc.toml type-check:test` ✅ exit 0

## Notes

- 不新增任何依赖。
- 不触碰 zod schema / UI / CI 配置。
- 提交遵循 [约定式提交](https://www.conventionalcommits.org/zh-hans/v1.0.0/)。
