### PR TITLE
feat(roll-call): support weighted probability via sampling

### DIFF
--- a/__tests__/roll-call.spec.ts
+++ b/__tests__/roll-call.spec.ts
@@ -95,3 +95,140 @@ describe.concurrent.todo('useRollCall', () => {
     expect(inst.value.currentValue).toBeUndefined();
   });
 });
+
+describe('useRollCall (weighted)', () => {
+  it('所有选项均为默认权重时保持顺序循环', () => {
+    const inst = useRollCall({
+      options: ['A', 'B', 'C'],
+      duration,
+    });
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(0);
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(1);
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(2);
+    expect(inst.value.currentValue).toBe('C');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(0);
+    expect(inst.value.currentValue).toBe('A');
+  });
+
+  it('加权采样分布大致符合权重比', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration, weight: 1 },
+        { value: 'B', duration, weight: 3 },
+      ],
+      duration,
+    });
+    let countA = 0;
+    let countB = 0;
+    for (let i = 0; i < 10000; i++) {
+      inst.value.next();
+      if (inst.value.currentValue === 'A')
+        countA++;
+      else
+        countB++;
+    }
+    expect(countB).toBeGreaterThan(countA * 2.5);
+    expect(countB).toBeLessThan(countA * 3.5);
+  });
+
+  it('支持非整数权重', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration, weight: 1.5 },
+        { value: 'B', duration, weight: 1 },
+      ],
+      duration,
+    });
+    let countA = 0;
+    let countB = 0;
+    for (let i = 0; i < 10000; i++) {
+      inst.value.next();
+      if (inst.value.currentValue === 'A')
+        countA++;
+      else
+        countB++;
+    }
+    expect(countA).toBeGreaterThan(countB);
+  });
+
+  it('非法权重回退为 1（保持顺序循环）', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration, weight: Number.NaN },
+        { value: 'B', duration, weight: 0 },
+        { value: 'C', duration, weight: -1 },
+        { value: 'D', duration, weight: Number.POSITIVE_INFINITY },
+      ],
+      duration,
+    });
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(0);
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(1);
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(2);
+    expect(inst.value.currentValue).toBe('C');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(3);
+    expect(inst.value.currentValue).toBe('D');
+  });
+
+  it('字符串与对象混合时按权重抽样', () => {
+    const inst = useRollCall({
+      options: ['A', { value: 'B', duration, weight: 2 }],
+      duration,
+    });
+    let countA = 0;
+    let countB = 0;
+    for (let i = 0; i < 10000; i++) {
+      inst.value.next();
+      if (inst.value.currentValue === 'A')
+        countA++;
+      else
+        countB++;
+    }
+    expect(countB).toBeGreaterThan(countA);
+  });
+
+  it('对象未指定权重时默认为 1（顺序循环）', () => {
+    const inst = useRollCall({
+      options: [
+        { value: 'A', duration },
+        { value: 'B', duration },
+      ],
+      duration,
+    });
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(0);
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(1);
+    expect(inst.value.currentValue).toBe('B');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(0);
+    expect(inst.value.currentValue).toBe('A');
+    inst.value.next();
+    expect(inst.value.currentIndex).toBe(1);
+    expect(inst.value.currentValue).toBe('B');
+  });
+
+  it('纯字符串选项顺序循环并回绕', () => {
+    const inst = useRollCall({
+      options: ['A', 'B'],
+      duration,
+    });
+    const expected = ['A', 'B', 'A', 'B', 'A'];
+    for (const v of expected) {
+      inst.value.next();
+      expect(inst.value.currentValue).toBe(v);
+    }
+  });
+});

--- a/src/utils/roll-call.ts
+++ b/src/utils/roll-call.ts
@@ -8,6 +8,8 @@ export interface RollCallAdvancedOption {
   value: string
   /** 此选项在随机时停留的时间（单位：ms） */
   duration: number
+  /** 此选项被抽中的权重（默认 1，必须为正有限数，否则视为 1） */
+  weight?: number
 }
 
 /** 待点选项 */
@@ -41,6 +43,52 @@ export interface RollCallController {
   reset: () => void
 }
 
+/** 获取选项的权重：非有限值或 ≤ 0 时视为 1 */
+function getWeight(option: RollCallOption): number {
+  if (typeof option === 'string')
+    return 1;
+  const w = option.weight;
+  if (w === undefined)
+    return 1;
+  return Number.isFinite(w) && w > 0 ? w : 1;
+}
+
+/** 累计权重与总权重；若所有权重均为默认值 1，则返回 null（保持顺序循环） */
+function buildCumulativeWeights(options: RollCallOption[]): { cumulative: number[], total: number } | null {
+  let allDefault = true;
+  const weights: number[] = [];
+  for (const opt of options) {
+    const w = getWeight(opt);
+    if (w !== 1)
+      allDefault = false;
+    weights.push(w);
+  }
+  if (allDefault)
+    return null;
+  const cumulative: number[] = [];
+  let sum = 0;
+  for (const w of weights) {
+    sum += w;
+    cumulative.push(sum);
+  }
+  return { cumulative, total: sum };
+}
+
+/** 通过逆 CDF + 二分查找从累计权重中抽样，返回被选中的下标 */
+function sampleWeighted(cumulative: number[], total: number): number {
+  const r = Math.random() * total;
+  let lo = 0;
+  let hi = cumulative.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (cumulative[mid] < r)
+      lo = mid + 1;
+    else
+      hi = mid;
+  }
+  return lo;
+}
+
 /**
  * 点名。
  *
@@ -53,10 +101,18 @@ export default function useRollCall(config: RollCallConfig): Ref<RollCallControl
   const currentValue = ref<string | undefined>(defaultValue);
   const currentDuration = ref(duration);
 
+  // 当任一选项设置了非默认权重时使用加权采样，否则保持顺序循环（向后兼容）
+  const weightedDist = buildCumulativeWeights(options);
+
   const next = () => {
-    let i = (currentIndex.value ?? -1) + 1; // 若未开始，下一个为第一个，即下标 -1+1
-    if (i >= options.length) // 越界
-      i = 0;
+    let i: number;
+    if (weightedDist) {
+      i = sampleWeighted(weightedDist.cumulative, weightedDist.total);
+    } else {
+      i = (currentIndex.value ?? -1) + 1; // 若未开始，下一个为第一个，即下标 -1+1
+      if (i >= options.length) // 越界
+        i = 0;
+    }
     const incoming = options[i]!;
     currentValue.value = rollCallOptionToString(incoming);
     currentIndex.value = i;


### PR DESCRIPTION
## What

Resolves #61.

为 `useRollCall` 增加按权重调整抽取概率的能力：在 `RollCallAdvancedOption` 上新增可选字段 `weight`（默认 `1`）。

## Why

#61 希望让某些选项（如「重点关注名单」）在点名时被抽中的概率更高。原 issue 给出的规格是 `A1 B2 C3` → 待选队列 `A B B C C C`，即按权重展开队列后再循环。#75 正是按此规格实现的，但维护者反馈「不应采用'展开'的方式实现权重」，因此本 PR 改用加权采样实现。

## How

使用**逆 CDF + 二分查找**进行加权采样，而非展开队列：

- 在 `useRollCall` 构造时，调用 `buildCumulativeWeights(options)` 计算累计权重数组（在闭包内只计算一次，O(n)）。
- 当**所有**选项权重均为默认值（`1` 或未指定）时，返回 `null`，`next()` 走原顺序循环路径——该路径的三行循环逻辑与原代码完全一致（未改动），完全向后兼容。
- 当**任一**选项设置了非默认权重时，`next()` 每次调用 `Math.random() * totalWeight` 生成一个随机数，再用二分查找（`lower_bound`）定位到对应选项的下标。每个选项被抽中的概率严格正比于其权重。

### 相比展开方式的优势

| 维度 | 展开方式（#75） | 加权采样（本 PR） |
|---|---|---|
| 内存 | O(Σweights)，权重 1000 即展开为 1000 元素数组 | O(n)，仅存累计权重 |
| 非整数权重 | 不支持（向下取整，`2.9 → 2`） | 原生支持（`1.5`、`0.7` 等） |
| 权重 < 1 | 不支持（视为 1） | 原生支持（「不太想抽到」的选项） |
| 统计等价性 | — | 长时间运行下，每个选项被停住的概率 ∝ 权重，与展开方式等价 |

### 权重校验

- 字符串选项：权重视为 `1`。
- 对象选项未指定 `weight`：视为 `1`。
- `weight` 非有限值（`NaN` / `±Infinity`）或 `≤ 0`：视为 `1`，避免静默丢弃或死循环。
- 其余值（包括非整数、< 1 的正数）原样使用。

## Changes

### `src/utils/roll-call.ts` (+59, -3)

- `RollCallAdvancedOption` 新增可选 `weight?: number`。
- 新增三个模块级辅助函数：
  - `getWeight(option)` — 取选项权重，做合法性校验。
  - `buildCumulativeWeights(options)` — 构建累计权重数组；若所有权重均为 `1` 则返回 `null`（信号：走顺序循环路径）。
  - `sampleWeighted(cumulative, total)` — 逆 CDF + 二分查找抽样。
- `useRollCall` 在构造时调用 `buildCumulativeWeights(options)` 一次（闭包内只计算一次），`next()` 据此分支：
  - `weightedDist` 非空：加权抽样。
  - `weightedDist` 为空：原顺序循环逻辑（三行循环代码与原代码完全一致，未改动）。
- `currentIndex` 语义不变：始终是被展示选项在 `options` 中的下标。
- `duration` 处理不变：对象选项仍可通过 `duration` 字段覆盖默认停留时间。
- 未新增空 `options` 守卫——保持与原代码一致的最小变更。

### `__tests__/roll-call.spec.ts` (+137)

新增 `describe('useRollCall (weighted)', ...)` 块（非 `.todo`，实际执行），7 个同步测试：

1. 所有选项均为默认权重时保持顺序循环（向后兼容）。
2. 加权采样分布大致符合权重比（`A:1, B:3`，10000 次抽样，`countB ∈ (2.5×countA, 3.5×countA)`）。
3. 支持非整数权重（`A:1.5, B:1` → `countA > countB`）。
4. 非法权重（`NaN` / `0` / `-1` / `+Infinity`）回退为 `1`，保持顺序循环。
5. 字符串与对象混合时按权重抽样。
6. 对象未指定 `weight` 时默认为 `1`（顺序循环）。
7. 纯字符串选项顺序循环并回绕。

既有 `describe.concurrent.todo('useRollCall', ...)` 块保持不变。

## Backward compatibility

- 纯字符串与 `{ value, duration }` 形式的选项行为完全不变（权重默认 `1`，走顺序循环路径）。
- `defaultIndex` / `defaultValue` 语义不变。
- 唯一新增行为：当任一选项设置了非默认 `weight` 时，`next()` 改为加权抽样。在此模式下，`defaultIndex` 仅用于初始化展示状态，不再决定后续抽样序列（这符合「按权重随机」的语义）。

## Out of scope（留作后续 PR）

- 名单编辑器 UI 暴露 `weight` 字段（需要更新 zod schema 与 `dynamic-input.tsx`）。
- 启用既有 `.todo` 测试块（依赖真实定时器，CI 中已用 `if: 0` 关闭，留待后续单独处理）。

## Verification

- `bun run lint` ✅
- `bun run test -- __tests__/roll-call.spec.ts` ✅（7 passed | 7 todo）
- `bun run --config=bunfig.vue-tsc.toml type-check:app` ✅
- `bun run --config=bunfig.vue-tsc.toml type-check:test` ✅

## Notes

- 不新增任何依赖。
- 不触碰 zod schema / UI / CI 配置。
- 提交遵循[约定式提交 1.0.0](https://www.conventionalcommits.org/zh-hans/v1.0.0/)。
- 与 #75 的关系：#75 采用展开方式，已被维护者拒绝；本 PR 改用加权采样，直接回应维护者反馈。
- 本 PR 由代替账号所有者操作的 AI agent（`Luyicheng-Agent`）提交，与 #75 系同一账号。若维护者希望 AI agent 暂停向本仓库提交，请直接告知。

若维护者对加权采样的具体实现方式（逆 CDF + 二分查找）有偏好或顾虑，或希望采用其他方案（如 Efraimidis–Spirakis 加权蓄水池抽样等），欢迎指出，我可以调整。
